### PR TITLE
Reuse key hash for bloom filter checks

### DIFF
--- a/src/ZoneTree.UnitTests/DiskSegmentFactoryTests.cs
+++ b/src/ZoneTree.UnitTests/DiskSegmentFactoryTests.cs
@@ -1,3 +1,4 @@
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.Segments.Disk;
 using ZoneTree.Serializers;
@@ -127,13 +128,15 @@ public sealed class DiskSegmentFactoryTests
     {
       for (var i = 0; i < recordCount; ++i)
       {
-        Assert.That(diskSegment.TryGet(keys[i], out var value), Is.True);
+        var keyHashProvider = new KeyHashProvider<TKey>();
+        Assert.That(diskSegment.TryGet(keys[i], out var value, ref keyHashProvider), Is.True);
         Assert.That(value, Is.EqualTo(values[i]));
       }
 
       for (var i = recordCount - 1; i >= 0; --i)
       {
-        Assert.That(diskSegment.TryGet(keys[i], out var value), Is.True);
+        var keyHashProvider = new KeyHashProvider<TKey>();
+        Assert.That(diskSegment.TryGet(keys[i], out var value, ref keyHashProvider), Is.True);
         Assert.That(value, Is.EqualTo(values[i]));
       }
 
@@ -148,7 +151,8 @@ public sealed class DiskSegmentFactoryTests
       ];
       foreach (var index in mixedIndexes)
       {
-        Assert.That(diskSegment.TryGet(keys[index], out var value), Is.True);
+        var keyHashProvider = new KeyHashProvider<TKey>();
+        Assert.That(diskSegment.TryGet(keys[index], out var value, ref keyHashProvider), Is.True);
         Assert.That(value, Is.EqualTo(values[index]));
       }
     }

--- a/src/ZoneTree.UnitTests/DiskSegmentSearchHintTests.cs
+++ b/src/ZoneTree.UnitTests/DiskSegmentSearchHintTests.cs
@@ -1,5 +1,6 @@
 using ZoneTree.Collections;
 using ZoneTree.Comparers;
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.Segments.Block;
 using ZoneTree.Segments.Disk;
@@ -105,7 +106,7 @@ public sealed class DiskSegmentSearchHintTests
 
     AssertGet(segment, 0);
     AssertGet(segment, 1);
-    Assert.Throws<InvalidOperationException>(() => segment.TryGet(2, out _));
+    Assert.Throws<InvalidOperationException>(() => TryGet(segment, 2, out _));
 
     Assert.That(segment.LastBlockPin, Is.Not.Null);
     Assert.That(segment.LastBlockPin.Device1, Is.Null);
@@ -114,8 +115,14 @@ public sealed class DiskSegmentSearchHintTests
 
   static void AssertGet(TestDiskSegment segment, int key)
   {
-    Assert.That(segment.TryGet(key, out var value), Is.True);
+    Assert.That(TryGet(segment, key, out var value), Is.True);
     Assert.That(value, Is.EqualTo(key + 100));
+  }
+
+  static bool TryGet(TestDiskSegment segment, int key, out int value)
+  {
+    var keyHashProvider = new KeyHashProvider<int>();
+    return segment.TryGet(key, out value, ref keyHashProvider);
   }
 
   static TestDiskSegment CreateSegment(

--- a/src/ZoneTree.UnitTests/MultiPartDiskSegmentLeaseTests.cs
+++ b/src/ZoneTree.UnitTests/MultiPartDiskSegmentLeaseTests.cs
@@ -63,7 +63,8 @@ public sealed class MultiPartDiskSegmentLeaseTests
         Assert.That(DeviceExists(deviceManager, preservedPart), Is.True);
         Assert.That(DeviceExists(deviceManager, droppedPart), Is.False);
         Assert.That(MultiPartMetadataExists(deviceManager, multiPart), Is.False);
-        Assert.That(preservedPart.TryGet(1, out var value), Is.True);
+        var keyHashProvider = new KeyHashProvider<int>();
+        Assert.That(preservedPart.TryGet(1, out var value, ref keyHashProvider), Is.True);
         Assert.That(value, Is.EqualTo(1));
       });
     }

--- a/src/ZoneTree/Collections/ConcurrentBloomFilter.cs
+++ b/src/ZoneTree/Collections/ConcurrentBloomFilter.cs
@@ -1,12 +1,11 @@
 using System.Runtime.CompilerServices;
-using ZoneTree.Hashers;
 
 namespace ZoneTree.Collections;
 
 /// <summary>
 /// A fixed-size Bloom filter supporting concurrent readers and writers.
 /// </summary>
-public sealed class ConcurrentBloomFilter<TKey>
+public sealed class ConcurrentBloomFilter
 {
   const long MaximumBitCount = 1L << 30;
 
@@ -14,14 +13,10 @@ public sealed class ConcurrentBloomFilter<TKey>
 
   readonly ulong WordMask;
 
-  readonly IKeyHasher<TKey> KeyHasher;
-
   public ConcurrentBloomFilter(
       int expectedItemCount,
-      int bitsPerItem,
-      IKeyHasher<TKey> keyHasher)
+      int bitsPerItem)
   {
-    KeyHasher = keyHasher;
     var requestedBitCount = Math.Max(
         64L,
         (long)expectedItemCount * bitsPerItem);
@@ -34,23 +29,23 @@ public sealed class ConcurrentBloomFilter<TKey>
   }
 
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
-  public void Add(in TKey key)
+  public void Add(int hashCode)
   {
-    GetWordAndBitMask(in key, out var wordIndex, out var bitMask);
+    GetWordAndBitMask(hashCode, out var wordIndex, out var bitMask);
     Interlocked.Or(ref Words[wordIndex], bitMask);
   }
 
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
-  public bool MightContain(in TKey key)
+  public bool MightContain(int hashCode)
   {
-    GetWordAndBitMask(in key, out var wordIndex, out var bitMask);
+    GetWordAndBitMask(hashCode, out var wordIndex, out var bitMask);
     return (Volatile.Read(ref Words[wordIndex]) & bitMask) == bitMask;
   }
 
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
-  void GetWordAndBitMask(in TKey key, out int wordIndex, out long bitMask)
+  void GetWordAndBitMask(int hashCode, out int wordIndex, out long bitMask)
   {
-    var hash = Mix(unchecked((uint)KeyHasher.GetHashCode(in key)));
+    var hash = Mix(unchecked((uint)hashCode));
     var firstBit = (int)(hash & 63);
     var bitStep = (int)((hash >> 6) & 31) * 2 + 1;
     var secondBit = (firstBit + bitStep) & 63;

--- a/src/ZoneTree/Core/ZoneTree.ReadWrite.cs
+++ b/src/ZoneTree/Core/ZoneTree.ReadWrite.cs
@@ -1,6 +1,7 @@
 using ZoneTree.Collections;
 using ZoneTree.Collections.BTree;
 using ZoneTree.Exceptions;
+using ZoneTree.Hashers;
 using ZoneTree.Segments;
 
 namespace ZoneTree.Core;
@@ -9,17 +10,21 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
 {
   public bool ContainsKey(in TKey key)
   {
-    if (MutableSegment.TryGet(key, out TValue value))
+    var keyHashProvider = new KeyHashProvider<TKey>();
+    if (MutableSegment.TryGet(key, out TValue value, ref keyHashProvider))
       return !IsDeleted(key, value);
 
-    return TryGetFromReadonlySegments(in key, out _);
+    return TryGetFromReadonlySegments(in key, out _, ref keyHashProvider);
   }
 
-  bool TryGetFromReadonlySegments(in TKey key, out TValue value)
+  bool TryGetFromReadonlySegments(
+      in TKey key,
+      out TValue value,
+      ref KeyHashProvider<TKey> keyHashProvider)
   {
     foreach (var segment in ReadOnlySegmentQueue)
     {
-      if (segment.TryGet(key, out value))
+      if (segment.TryGet(key, out value, ref keyHashProvider))
       {
         return !IsDeleted(key, value);
       }
@@ -29,14 +34,14 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
     {
       try
       {
-        if (DiskSegment.TryGet(key, out value))
+        if (DiskSegment.TryGet(key, out value, ref keyHashProvider))
         {
           return !IsDeleted(key, value);
         }
 
         foreach (var segment in BottomSegmentQueue)
         {
-          if (segment.TryGet(key, out value))
+          if (segment.TryGet(key, out value, ref keyHashProvider))
           {
             return !IsDeleted(key, value);
           }
@@ -52,11 +57,12 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
 
   public bool TryGet(in TKey key, out TValue value)
   {
-    if (MutableSegment.TryGet(key, out value))
+    var keyHashProvider = new KeyHashProvider<TKey>();
+    if (MutableSegment.TryGet(key, out value, ref keyHashProvider))
     {
       return !IsDeleted(key, value);
     }
-    return TryGetFromReadonlySegments(in key, out value);
+    return TryGetFromReadonlySegments(in key, out value, ref keyHashProvider);
   }
 
   public bool TryAdd(in TKey key, in TValue value, out long opIndex)
@@ -79,7 +85,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
     if (IsReadOnly)
       throw new ZoneTreeIsReadOnlyException();
 
-    if (MutableSegment.TryGet(key, out value))
+    var keyHashProvider = new KeyHashProvider<TKey>();
+    if (MutableSegment.TryGet(key, out value, ref keyHashProvider))
     {
       if (IsDeleted(key, value))
       {
@@ -87,7 +94,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         return false;
       }
     }
-    else if (!TryGetFromReadonlySegments(in key, out value))
+    else if (!TryGetFromReadonlySegments(in key, out value, ref keyHashProvider))
     {
       opIndex = 0;
       return false;
@@ -114,12 +121,13 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
 
     lock (AtomicUpdateLock)
     {
-      if (MutableSegment.TryGet(key, out value))
+      var keyHashProvider = new KeyHashProvider<TKey>();
+      if (MutableSegment.TryGet(key, out value, ref keyHashProvider))
       {
         if (IsDeleted(key, value))
           return false;
       }
-      else if (!TryGetFromReadonlySegments(in key, out value))
+      else if (!TryGetFromReadonlySegments(in key, out value, ref keyHashProvider))
         return false;
 
       if (!valueUpdater(ref value))
@@ -185,6 +193,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
     IMutableSegment<TKey, TValue> mutableSegment;
     var opIndex = 0L;
     result ??= EmptyOperationResultDelegate;
+    var keyHashProvider = new KeyHashProvider<TKey>();
 
     while (true)
     {
@@ -195,7 +204,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         {
           status = AddOrUpdateResult.RETRY_SEGMENT_IS_FULL;
         }
-        else if (mutableSegment.TryGet(in key, out var existing))
+        else if (mutableSegment.TryGet(in key, out var existing, ref keyHashProvider))
         {
           if (!valueUpdater(ref existing))
           {
@@ -209,7 +218,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             return false;
           }
         }
-        else if (TryGetFromReadonlySegments(in key, out existing))
+        else if (TryGetFromReadonlySegments(in key, out existing, ref keyHashProvider))
         {
           if (!valueUpdater(ref existing))
           {
@@ -259,6 +268,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
     IMutableSegment<TKey, TValue> mutableSegment;
     var opIndex = 0L;
     result ??= EmptyOperationResultDelegate;
+    var keyHashProvider = new KeyHashProvider<TKey>();
     while (true)
     {
       lock (AtomicUpdateLock)
@@ -268,7 +278,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         {
           status = AddOrUpdateResult.RETRY_SEGMENT_IS_FULL;
         }
-        else if (mutableSegment.TryGet(in key, out var existing))
+        else if (mutableSegment.TryGet(in key, out var existing, ref keyHashProvider))
         {
           if (!valueUpdater(ref existing))
           {
@@ -282,7 +292,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             return false;
           }
         }
-        else if (TryGetFromReadonlySegments(in key, out existing))
+        else if (TryGetFromReadonlySegments(in key, out existing, ref keyHashProvider))
         {
           if (!valueUpdater(ref existing))
           {

--- a/src/ZoneTree/Core/ZoneTree.cs
+++ b/src/ZoneTree/Core/ZoneTree.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using ZoneTree.Collections;
 using ZoneTree.Comparers;
+using ZoneTree.Hashers;
 using ZoneTree.Logger;
 using ZoneTree.Options;
 using ZoneTree.Segments;
@@ -317,7 +318,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
       while (iterator.Next())
       {
         var key = iterator.CurrentKey;
-        var hasKey = diskSegment.ContainsKey(key);
+        var keyHashProvider = new KeyHashProvider<TKey>();
+        var hasKey = diskSegment.ContainsKey(key, ref keyHashProvider);
         var isDeleted = IsDeleted(key, iterator.CurrentValue);
         if (hasKey)
         {

--- a/src/ZoneTree/Directory.Build.props
+++ b/src/ZoneTree/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree</PackageId>
     <Title>ZoneTree</Title>
-    <ProductVersion>1.9.5.0</ProductVersion>
-    <Version>1.9.5.0</Version>
+    <ProductVersion>1.9.6.0</ProductVersion>
+    <Version>1.9.6.0</Version>
     <AssemblyTitle>ZoneTree</AssemblyTitle>
     <Description>ZoneTree is a persistent, high-performance, transactional, ACID-compliant ordered key-value database and LSM-tree storage engine for .NET.</Description>
     <Summary>

--- a/src/ZoneTree/Hashers/KeyHashProvider.cs
+++ b/src/ZoneTree/Hashers/KeyHashProvider.cs
@@ -1,0 +1,22 @@
+namespace ZoneTree.Hashers;
+
+public ref struct KeyHashProvider<TKey>
+{
+  // Hash code 0 is the missing sentinel. If a key's hash is exactly 0
+  // (1 / 2^32 for a well-distributed hash), it may be recalculated.
+  const int MissingHashCode = 0;
+
+  int HashCode;
+
+  public KeyHashProvider()
+  {
+    HashCode = MissingHashCode;
+  }
+
+  public int GetHashCode(in TKey key, IKeyHasher<TKey> keyHasher)
+  {
+    if (HashCode == MissingHashCode)
+      HashCode = keyHasher.GetHashCode(in key);
+    return HashCode;
+  }
+}

--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using ZoneTree.Collections;
 using ZoneTree.Comparers;
 using ZoneTree.Exceptions;
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.Segments.Block;
 using ZoneTree.Segments.RandomAccess;
@@ -168,7 +169,7 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
         diskOptions.ValueCacheRecordLifeTimeInMillisecond);
   }
 
-  public bool ContainsKey(in TKey key)
+  public bool ContainsKey(in TKey key, ref KeyHashProvider<TKey> keyHashProvider)
   {
     var sparseArrayLength = SparseArray.Count;
     long lower = 0;
@@ -198,7 +199,7 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     return ReadValue(index);
   }
 
-  public bool TryGet(in TKey key, out TValue value)
+  public bool TryGet(in TKey key, out TValue value, ref KeyHashProvider<TKey> keyHashProvider)
   {
     var searchHint = SearchHints?.Value;
     var direction = searchHint?.Direction ?? 0;

--- a/src/ZoneTree/Segments/IReadOnlySegment.cs
+++ b/src/ZoneTree/Segments/IReadOnlySegment.cs
@@ -1,4 +1,5 @@
 using ZoneTree.Collections;
+using ZoneTree.Hashers;
 
 namespace ZoneTree.Segments;
 
@@ -10,9 +11,9 @@ public interface IReadOnlySegment<TKey, TValue>
 
   long MaximumOpIndex { get; }
 
-  bool ContainsKey(in TKey key);
+  bool ContainsKey(in TKey key, ref KeyHashProvider<TKey> keyHashProvider);
 
-  bool TryGet(in TKey key, out TValue value);
+  bool TryGet(in TKey key, out TValue value, ref KeyHashProvider<TKey> keyHashProvider);
 
   void Drop();
 

--- a/src/ZoneTree/Segments/InMemory/FrozenMutableSegment.cs
+++ b/src/ZoneTree/Segments/InMemory/FrozenMutableSegment.cs
@@ -1,6 +1,7 @@
 using ZoneTree.Collections;
 using ZoneTree.Collections.BTree;
 using ZoneTree.Core;
+using ZoneTree.Hashers;
 
 namespace ZoneTree.Segments.InMemory;
 
@@ -25,9 +26,9 @@ public sealed class FrozenMutableSegment<TKey, TValue> : IMutableSegment<TKey, T
 
   public bool IsFullyFrozen => false;
 
-  public bool ContainsKey(in TKey key)
+  public bool ContainsKey(in TKey key, ref KeyHashProvider<TKey> keyHashProvider)
   {
-    return mutableSegment.ContainsKey(key);
+    return mutableSegment.ContainsKey(key, ref keyHashProvider);
   }
 
   public AddOrUpdateResult Delete(in TKey key, out long opIndex)
@@ -60,9 +61,9 @@ public sealed class FrozenMutableSegment<TKey, TValue> : IMutableSegment<TKey, T
     mutableSegment.ReleaseResources();
   }
 
-  public bool TryGet(in TKey key, out TValue value)
+  public bool TryGet(in TKey key, out TValue value, ref KeyHashProvider<TKey> keyHashProvider)
   {
-    return mutableSegment.TryGet(key, out value);
+    return mutableSegment.TryGet(key, out value, ref keyHashProvider);
   }
 
   public AddOrUpdateResult Upsert(in TKey key, in TValue value, out long opIndex)

--- a/src/ZoneTree/Segments/InMemory/MutableSegment.cs
+++ b/src/ZoneTree/Segments/InMemory/MutableSegment.cs
@@ -2,6 +2,7 @@ using ZoneTree.Collections;
 using ZoneTree.Collections.BTree;
 using ZoneTree.Comparers;
 using ZoneTree.Core;
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.WAL;
 
@@ -21,7 +22,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
 
   readonly BTree<TKey, TValue> BTree;
 
-  readonly ConcurrentBloomFilter<TKey> BloomFilter;
+  readonly ConcurrentBloomFilter BloomFilter;
 
   readonly IRefComparer<TKey> Comparer;
 
@@ -112,7 +113,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
       var value = values[i];
       // TODO: Search if we can create faster construction
       // of mutable segment from log entries.
-      BloomFilter?.Add(in key);
+      AddToBloomFilter(in key);
       BTree.Upsert(in key, in value, out var _);
     }
   }
@@ -136,26 +137,24 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
       {
         continue;
       }
-      BloomFilter?.Add(in key);
+      AddToBloomFilter(in key);
       BTree.Upsert(in key, in value, out var _);
     }
   }
 
-  public bool ContainsKey(in TKey key)
+  public bool ContainsKey(in TKey key, ref KeyHashProvider<TKey> keyHashProvider)
   {
-    if (BTree.Length == 0)
-      return false;
-    if (BloomFilter != null &&
-        !BloomFilter.MightContain(in key))
+    if (BTree.Length == 0 || BloomFilter != null &&
+        !BloomFilter.MightContain(keyHashProvider.GetHashCode(in key, Options.KeyHasher)))
       return false;
     return BTree.ContainsKey(key);
   }
 
-  public bool TryGet(in TKey key, out TValue value)
+  public bool TryGet(in TKey key, out TValue value, ref KeyHashProvider<TKey> keyHashProvider)
   {
     if (BTree.Length == 0 ||
         (BloomFilter != null &&
-         !BloomFilter.MightContain(in key)))
+         !BloomFilter.MightContain(keyHashProvider.GetHashCode(in key, Options.KeyHasher))))
     {
       value = default;
       return false;
@@ -180,7 +179,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
         opIndex = 0;
         return AddOrUpdateResult.RETRY_SEGMENT_IS_FULL;
       }
-      BloomFilter?.Add(in key);
+      AddToBloomFilter(in key);
       var result = BTree.Upsert(in key, in value, out opIndex);
       WriteAheadLog.Append(in key, in value, opIndex);
       return result ? AddOrUpdateResult.ADDED : AddOrUpdateResult.UPDATED;
@@ -211,7 +210,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
         opIndex = 0;
         return AddOrUpdateResult.RETRY_SEGMENT_IS_FULL;
       }
-      BloomFilter?.Add(in key);
+      AddToBloomFilter(in key);
       var result = BTree.Upsert(in key, valueGetter, out var value, out opIndex);
       WriteAheadLog.Append(in key, in value, opIndex);
       return result ? AddOrUpdateResult.ADDED : AddOrUpdateResult.UPDATED;
@@ -242,7 +241,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
 
       TValue insertedValue = default;
 
-      BloomFilter?.Add(in key);
+      AddToBloomFilter(in key);
       var status = BTree
           .AddOrUpdate(key,
               void (ref TValue x) =>
@@ -270,16 +269,20 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
     new Thread(FreezeWriteAheadLog).Start();
   }
 
-  ConcurrentBloomFilter<TKey> CreateBloomFilter(
+  ConcurrentBloomFilter CreateBloomFilter(
       ZoneTreeOptions<TKey, TValue> options)
   {
     var bitsPerItem = options.MutableSegmentBloomFilterBitsPerItem;
     return bitsPerItem == 0 ?
         null :
-        new ConcurrentBloomFilter<TKey>(
+        new ConcurrentBloomFilter(
             MutableSegmentMaxItemCount,
-            bitsPerItem,
-            options.KeyHasher);
+            bitsPerItem);
+  }
+
+  void AddToBloomFilter(in TKey key)
+  {
+    BloomFilter?.Add(Options.KeyHasher.GetHashCode(in key));
   }
 
   void FreezeWriteAheadLog()

--- a/src/ZoneTree/Segments/InMemory/ReadOnlySegment.cs
+++ b/src/ZoneTree/Segments/InMemory/ReadOnlySegment.cs
@@ -1,6 +1,7 @@
 using ZoneTree.Collections;
 using ZoneTree.Comparers;
 using ZoneTree.Core;
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.Segments.Block;
 using ZoneTree.WAL;
@@ -49,7 +50,7 @@ public sealed class ReadOnlySegment<TKey, TValue> : IReadOnlySegment<TKey, TValu
         ZoneTree<TKey, TValue>.SegmentWalCategory);
   }
 
-  public bool TryGet(in TKey key, out TValue value)
+  public bool TryGet(in TKey key, out TValue value, ref KeyHashProvider<TKey> keyHashProvider)
   {
     int index = BinarySearchAlgorithms
         .BinarySearch(SortedKeys, 0, SortedKeys.Count - 1, Comparer, in key);
@@ -62,7 +63,7 @@ public sealed class ReadOnlySegment<TKey, TValue> : IReadOnlySegment<TKey, TValu
     return true;
   }
 
-  public bool ContainsKey(in TKey key)
+  public bool ContainsKey(in TKey key, ref KeyHashProvider<TKey> keyHashProvider)
   {
     int index = BinarySearchAlgorithms
         .BinarySearch(SortedKeys, 0, SortedKeys.Count - 1, Comparer, in key);

--- a/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
@@ -4,6 +4,7 @@ using ZoneTree.AbstractFileStream;
 using ZoneTree.Collections;
 using ZoneTree.Comparers;
 using ZoneTree.Exceptions;
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.Segments.Block;
 using ZoneTree.Segments.Disk;
@@ -241,7 +242,7 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
           "Cannot attach an iterator after disk segment retirement has started.");
   }
 
-  public bool ContainsKey(in TKey key)
+  public bool ContainsKey(in TKey key, ref KeyHashProvider<TKey> keyHashProvider)
   {
     var sparseArrayLength = PartKeys.Length;
     (var left, var found) = SearchLastSmallerOrEqualPositionInSparseArray(in key);
@@ -251,7 +252,7 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
       return false;
 
     var partIndex = left / 2;
-    return Parts[partIndex].ContainsKey(in key);
+    return Parts[partIndex].ContainsKey(in key, ref keyHashProvider);
   }
 
   public void Dispose()
@@ -512,7 +513,7 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
     }
   }
 
-  public bool TryGet(in TKey key, out TValue value)
+  public bool TryGet(in TKey key, out TValue value, ref KeyHashProvider<TKey> keyHashProvider)
   {
     var sparseArrayLength = PartKeys.Length;
     (var left, var found) = SearchLastSmallerOrEqualPositionInSparseArray(in key);
@@ -528,7 +529,7 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
     }
 
     var partIndex = left / 2;
-    return Parts[partIndex].TryGet(in key, out value);
+    return Parts[partIndex].TryGet(in key, out value, ref keyHashProvider);
   }
 
   #region Binary search

--- a/src/ZoneTree/Segments/NullDisk/NullDiskSegment.cs
+++ b/src/ZoneTree/Segments/NullDisk/NullDiskSegment.cs
@@ -1,4 +1,5 @@
 using ZoneTree.Collections;
+using ZoneTree.Hashers;
 using ZoneTree.Segments.Block;
 using ZoneTree.Segments.Disk;
 
@@ -18,7 +19,7 @@ public sealed class NullDiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   public int ReadBufferCount => 0;
 
-  public bool ContainsKey(in TKey key)
+  public bool ContainsKey(in TKey key, ref KeyHashProvider<TKey> keyHashProvider)
   {
     return false;
   }
@@ -43,7 +44,7 @@ public sealed class NullDiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     // Nothing to load
   }
 
-  public bool TryGet(in TKey key, out TValue value)
+  public bool TryGet(in TKey key, out TValue value, ref KeyHashProvider<TKey> keyHashProvider)
   {
     value = default;
     return false;


### PR DESCRIPTION
## Summary

This PR avoids recalculating the same key hash across segment bloom filter checks during a logical read.

A lightweight `KeyHashProvider<TKey>` is introduced and passed through internal segment `TryGet` / `ContainsKey` calls. The provider stores only one `int` hash code and computes it lazily when a bloom filter needs it.

`ConcurrentBloomFilter` is also simplified to work directly with hash codes instead of keys. It no longer carries `TKey` or `IKeyHasher<TKey>`.

## Changes

- Add `KeyHashProvider<TKey>` for lazy per-read hash reuse.
- Pass `ref KeyHashProvider<TKey>` through internal segment lookup APIs.
- Update mutable segment bloom checks to reuse the provider hash.
- Convert `ConcurrentBloomFilter<TKey>` into non-generic `ConcurrentBloomFilter`.
- Change bloom filter APIs to `Add(int hashCode)` and `MightContain(int hashCode)`.
- Keep the public `IZoneTree<TKey, TValue>` read API unchanged.
- Update direct segment unit-test calls for the new internal lookup signatures.
- Bump package version to `1.9.6.0`.

## Why

A single `ZoneTree.TryGet` / `ContainsKey` can probe multiple segments. When bloom filters are involved, each segment could previously calculate the same key hash independently.

This change computes the key hash once per logical read in the common case and reuses it across bloom filter checks. It also prepares the segment lookup path for optional disk-segment bloom filters later.

## Notes

`KeyHashProvider<TKey>` uses hash code `0` as the missing sentinel. If a key hash is exactly `0`, the hash may be recalculated. For a well-distributed 32-bit hash this is a `1 / 2^32` case, and correctness is unaffected.