### PR TITLE
Ease maintainer usage by automatically waiting for merges on disposal

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Documentation
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'README.md'
+      - 'docs/**'
+      - 'src/ZoneTree/docs/**'
+      - 'scripts/validate-docs/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'README.md'
+      - 'docs/**'
+      - 'src/ZoneTree/docs/**'
+      - 'scripts/validate-docs/**'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Validate links and navigation
+        run: dotnet run --project scripts/validate-docs/ValidateDocs.csproj --configuration Release

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ using ZoneTree;
 using var zoneTree = new ZoneTreeFactory<int, string>()
     .SetDataDirectory("data/my-zone-tree")
     .OpenOrCreate();
+using var maintainer = zoneTree.CreateMaintainer();
 
 zoneTree.Upsert(1, "Hello ZoneTree");
 
@@ -204,9 +205,10 @@ using var zoneTree = new ZoneTreeFactory<int, int>()
 
 ## Maintenance
 
-ZoneTree uses an LSM-tree architecture. Writes first enter a mutable segment and are later moved, merged, and compacted into persistent segments.
-
-For long-running applications, use the maintainer to run background maintenance.
+`CreateMaintainer()` returns an optional, ready-to-use background maintenance
+coordinator. It responds to ZoneTree events, starts and tracks merge operations
+according to configurable policies, and periodically releases inactive read
+buffers and cache entries.
 
 ```csharp
 using var zoneTree = new ZoneTreeFactory<int, string>()
@@ -216,12 +218,12 @@ using var zoneTree = new ZoneTreeFactory<int, string>()
 using var maintainer = zoneTree.CreateMaintainer();
 
 zoneTree.Upsert(1, "value");
-
-// Before shutdown, wait for background work if needed.
-maintainer.WaitForBackgroundThreads();
 ```
 
-Maintenance behavior can be tuned for different workloads.
+The maintainer is caller-owned and disposable; disposal waits for its tracked
+merge operations to finish. Without a maintainer, the caller is responsible for
+defining and coordinating maintenance through the state, events, and operations
+exposed by `zoneTree.Maintenance`.
 
 ---
 
@@ -303,7 +305,7 @@ Repository:
 
 Official documentation:
 
-* [Docs home](docs/README.md)
+* [Docs home](docs/index.md)
 * [Getting started](docs/getting-started.md)
 * [Reads and writes](docs/usage/reads-and-writes.md)
 * [Value mutability](docs/concepts/value-mutability.md)

--- a/scripts/validate-docs/Program.cs
+++ b/scripts/validate-docs/Program.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+var repositoryRoot = FindRepositoryRoot(args);
+var errors = new List<string>();
+
+var markdownFiles = GetMarkdownFiles(repositoryRoot, errors);
+foreach (var markdownFile in markdownFiles)
+  ValidateMarkdownLinks(repositoryRoot, markdownFile, errors);
+
+var navigationFiles = Directory
+  .EnumerateFiles(Path.Combine(repositoryRoot, "docs"), "_nav.json", SearchOption.AllDirectories)
+  .Order(StringComparer.Ordinal)
+  .ToArray();
+
+foreach (var navigationFile in navigationFiles)
+  ValidateNavigation(repositoryRoot, navigationFile, errors);
+
+if (errors.Count != 0)
+{
+  foreach (var error in errors)
+    Console.Error.WriteLine(error);
+  return 1;
+}
+
+Console.WriteLine(
+  $"Validated {markdownFiles.Count} Markdown files and {navigationFiles.Length} navigation files.");
+return 0;
+
+static string FindRepositoryRoot(string[] args)
+{
+  if (args.Length > 1)
+    throw new ArgumentException("Usage: ValidateDocs [repository-root]");
+
+  if (args.Length == 1)
+    return Path.GetFullPath(args[0]);
+
+  for (var directory = new DirectoryInfo(Environment.CurrentDirectory);
+       directory != null;
+       directory = directory.Parent)
+  {
+    if (File.Exists(Path.Combine(directory.FullName, "README.md")) &&
+        Directory.Exists(Path.Combine(directory.FullName, "docs")))
+      return directory.FullName;
+  }
+
+  throw new DirectoryNotFoundException(
+    "Could not find the repository root. Pass it as the first argument.");
+}
+
+static List<string> GetMarkdownFiles(string repositoryRoot, List<string> errors)
+{
+  var files = new List<string>();
+  AddRequiredFile(Path.Combine(repositoryRoot, "README.md"));
+
+  var docsDirectory = Path.Combine(repositoryRoot, "docs");
+  if (Directory.Exists(docsDirectory))
+  {
+    files.AddRange(Directory.EnumerateFiles(
+      docsDirectory,
+      "*.md",
+      SearchOption.AllDirectories));
+  }
+  else
+  {
+    errors.Add("Missing documentation directory: docs");
+  }
+
+  AddRequiredFile(Path.Combine(
+    repositoryRoot,
+    "src",
+    "ZoneTree",
+    "docs",
+    "ZoneTree",
+    "README-NUGET.md"));
+
+  files.Sort(StringComparer.Ordinal);
+  return files;
+
+  void AddRequiredFile(string path)
+  {
+    if (File.Exists(path))
+      files.Add(path);
+    else
+      errors.Add($"Missing documentation file: {RelativePath(repositoryRoot, path)}");
+  }
+}
+
+static void ValidateMarkdownLinks(
+  string repositoryRoot,
+  string markdownFile,
+  List<string> errors)
+{
+  var content = File.ReadAllText(markdownFile);
+  foreach (Match match in MarkdownLinkPattern().Matches(content))
+  {
+    var target = match.Groups["target"].Value.Trim();
+    if (target.StartsWith('<') && target.EndsWith('>'))
+      target = target[1..^1];
+
+    if (IsExternalOrDocumentAnchor(target))
+      continue;
+
+    var fragmentIndex = target.IndexOf('#');
+    var pathPart = fragmentIndex < 0 ? target : target[..fragmentIndex];
+    if (string.IsNullOrWhiteSpace(pathPart))
+      continue;
+
+    try
+    {
+      pathPart = Uri.UnescapeDataString(pathPart)
+        .Replace('/', Path.DirectorySeparatorChar);
+      var containingDirectory = Path.GetDirectoryName(markdownFile)!;
+      var resolvedPath = Path.GetFullPath(Path.Combine(containingDirectory, pathPart));
+      if (!Path.Exists(resolvedPath))
+      {
+        errors.Add(
+          $"Broken local link in {RelativePath(repositoryRoot, markdownFile)}: {target}");
+      }
+    }
+    catch (Exception exception) when (
+      exception is ArgumentException or UriFormatException or NotSupportedException)
+    {
+      errors.Add(
+        $"Invalid local link in {RelativePath(repositoryRoot, markdownFile)}: " +
+        $"{target} ({exception.Message})");
+    }
+  }
+}
+
+static bool IsExternalOrDocumentAnchor(string target) =>
+  target.StartsWith('#') ||
+  target.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+  target.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+  target.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) ||
+  target.StartsWith("data:", StringComparison.OrdinalIgnoreCase);
+
+static void ValidateNavigation(
+  string repositoryRoot,
+  string navigationFile,
+  List<string> errors)
+{
+  JsonDocument navigation;
+  try
+  {
+    navigation = JsonDocument.Parse(File.ReadAllText(navigationFile));
+  }
+  catch (JsonException exception)
+  {
+    errors.Add(
+      $"Invalid JSON in {RelativePath(repositoryRoot, navigationFile)}: {exception.Message}");
+    return;
+  }
+
+  using (navigation)
+  {
+    var root = navigation.RootElement;
+    var itemIds = GetItemIds(root);
+    if (!root.TryGetProperty("sequence", out var sequence) ||
+        sequence.ValueKind != JsonValueKind.Array)
+      return;
+
+    var containingDirectory = Path.GetDirectoryName(navigationFile)!;
+    foreach (var element in sequence.EnumerateArray())
+    {
+      if (element.ValueKind != JsonValueKind.String)
+        continue;
+
+      var entry = element.GetString();
+      if (string.IsNullOrWhiteSpace(entry) || itemIds.Contains(entry))
+        continue;
+
+      var localEntry = entry.Replace('/', Path.DirectorySeparatorChar);
+      var resolvedPath = Path.GetFullPath(Path.Combine(containingDirectory, localEntry));
+      if (!Path.Exists(resolvedPath))
+      {
+        errors.Add(
+          $"Missing navigation target in {RelativePath(repositoryRoot, navigationFile)}: {entry}");
+      }
+    }
+  }
+}
+
+static HashSet<string> GetItemIds(JsonElement root)
+{
+  var itemIds = new HashSet<string>(StringComparer.Ordinal);
+  if (!root.TryGetProperty("items", out var items) ||
+      items.ValueKind != JsonValueKind.Array)
+    return itemIds;
+
+  foreach (var item in items.EnumerateArray())
+  {
+    if (item.ValueKind == JsonValueKind.Object &&
+        item.TryGetProperty("id", out var id) &&
+        id.ValueKind == JsonValueKind.String &&
+        id.GetString() is { Length: > 0 } value)
+      itemIds.Add(value);
+  }
+  return itemIds;
+}
+
+static string RelativePath(string repositoryRoot, string path) =>
+  Path.GetRelativePath(repositoryRoot, path).Replace('\\', '/');
+
+static Regex MarkdownLinkPattern() => MarkdownPatterns.Link;
+
+static class MarkdownPatterns
+{
+  internal static readonly Regex Link = new(
+    @"!?(?:\[[^\]]*\])\((?<target>[^)]+)\)",
+    RegexOptions.CultureInvariant);
+}

--- a/scripts/validate-docs/ValidateDocs.csproj
+++ b/scripts/validate-docs/ValidateDocs.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ZoneTree/Core/ZoneTreeMaintainer.cs
+++ b/src/ZoneTree/Core/ZoneTreeMaintainer.cs
@@ -10,8 +10,9 @@ namespace ZoneTree.Core;
 /// The maintainer for ZoneTree to control merge operations and memory compaction.
 /// </summary>
 /// <remarks>
-/// You must complete or cancel all pending tasks of this maintainer
-/// before disposing.
+/// Disposal waits for tracked background merge threads to finish. Call
+/// <see cref="TryCancelBackgroundThreads"/> before disposal to request
+/// cancellation instead of waiting for the current work to complete normally.
 /// </remarks>
 /// <typeparam name="TKey">The key type</typeparam>
 /// <typeparam name="TValue">The value type</typeparam>
@@ -286,7 +287,8 @@ public sealed class ZoneTreeMaintainer<TKey, TValue> : IMaintainer, IDisposable
   }
 
   /// <summary>
-  /// Disposes this maintainer.
+  /// Waits for tracked merge threads, stops periodic cache cleanup, detaches
+  /// event handlers, and disposes this maintainer.
   /// </summary>
   public void Dispose()
   {

--- a/src/ZoneTree/Core/ZoneTreeMaintainer.cs
+++ b/src/ZoneTree/Core/ZoneTreeMaintainer.cs
@@ -290,6 +290,7 @@ public sealed class ZoneTreeMaintainer<TKey, TValue> : IMaintainer, IDisposable
   /// </summary>
   public void Dispose()
   {
+    WaitForBackgroundThreads();
     PeriodicTimerCancellationTokenSource.Cancel();
     PeriodicTimerCancellationTokenSource.Dispose();
     Maintenance.OnMutableSegmentMovedForward -= OnMutableSegmentMovedForward;

--- a/src/ZoneTree/IMaintainer.cs
+++ b/src/ZoneTree/IMaintainer.cs
@@ -4,7 +4,9 @@ namespace ZoneTree;
 /// Provides functionality to manage merge operations and memory compaction within the ZoneTree.
 /// </summary>
 /// <remarks>
-/// Ensure that all pending operations are either completed or cancelled before disposing of this maintainer.
+/// Disposal waits for tracked background merge threads to finish. Call
+/// <see cref="TryCancelBackgroundThreads"/> before disposal to request
+/// cancellation instead of waiting for the current work to complete normally.
 /// </remarks>
 public interface IMaintainer : IDisposable
 {
@@ -49,11 +51,19 @@ public interface IMaintainer : IDisposable
   /// <summary>
   /// Blocks the calling thread until all background threads have finished execution.
   /// </summary>
+  /// <remarks>
+  /// Disposal also waits for background threads. Call this method when merge
+  /// completion must be observed before the maintainer's lifetime ends.
+  /// </remarks>
   void WaitForBackgroundThreads();
 
   /// <summary>
   /// Asynchronously waits for the completion of all background threads.
   /// </summary>
+  /// <remarks>
+  /// Use this method when merge completion must be observed asynchronously
+  /// before the maintainer's lifetime ends.
+  /// </remarks>
   /// <returns>A task representing the asynchronous operation.</returns>
   Task WaitForBackgroundThreadsAsync();
 

--- a/src/ZoneTree/docs/ZoneTree/README-NUGET.md
+++ b/src/ZoneTree/docs/ZoneTree/README-NUGET.md
@@ -72,6 +72,7 @@ using ZoneTree;
 using var zoneTree = new ZoneTreeFactory<int, string>()
     .SetDataDirectory("data/my-zone-tree")
     .OpenOrCreate();
+using var maintainer = zoneTree.CreateMaintainer();
 
 zoneTree.Upsert(1, "Hello ZoneTree");
 
@@ -205,9 +206,10 @@ using var zoneTree = new ZoneTreeFactory<int, int>()
 
 ## Maintenance
 
-ZoneTree uses an LSM-tree architecture. Writes first enter a mutable segment and are later moved, merged, and compacted into persistent segments.
-
-For long-running applications, use the maintainer to run background maintenance.
+`CreateMaintainer()` returns an optional, ready-to-use background maintenance
+coordinator. It responds to ZoneTree events, starts and tracks merge operations
+according to configurable policies, and periodically releases inactive read
+buffers and cache entries.
 
 ```csharp
 using var zoneTree = new ZoneTreeFactory<int, string>()
@@ -217,12 +219,12 @@ using var zoneTree = new ZoneTreeFactory<int, string>()
 using var maintainer = zoneTree.CreateMaintainer();
 
 zoneTree.Upsert(1, "value");
-
-// Before shutdown, wait for background work if needed.
-maintainer.WaitForBackgroundThreads();
 ```
 
-Maintenance behavior can be tuned for different workloads.
+The maintainer is caller-owned and disposable; disposal waits for its tracked
+merge operations to finish. Without a maintainer, the caller is responsible for
+defining and coordinating maintenance through the state, events, and operations
+exposed by `zoneTree.Maintenance`.
 
 ---
 


### PR DESCRIPTION
## Summary

Make `ZoneTreeMaintainer` automatically wait for its tracked background merge operations during disposal.

This simplifies the normal maintainer lifecycle:

```csharp
using var maintainer = zoneTree.CreateMaintainer();
```

Callers no longer need to explicitly call `WaitForBackgroundThreads()` before the maintainer leaves scope.

## Changes

* Call `WaitForBackgroundThreads()` from `ZoneTreeMaintainer.Dispose()`.
* Document that disposing the maintainer waits for tracked merge operations to finish.
* Clarify that callers can invoke `TryCancelBackgroundThreads()` before disposal when cancellation is preferred.
* Retain the explicit synchronous and asynchronous wait methods for cases where merge completion must be observed before disposal.
* Update the README and NuGet documentation to reflect the simplified lifecycle and explain the maintainer's responsibilities.

## Behavioral impact

`Dispose()` may now block while active merge operations finish. This is intentional and ensures that tracked background work is completed before the maintainer detaches its event handlers and releases its resources.
