### PR TITLE
Make KeyHasher optional when the mutable-segment Bloom filter is disabled.

### DIFF
--- a/benchmarks/profile-store/src/BenchmarkRunner.cs
+++ b/benchmarks/profile-store/src/BenchmarkRunner.cs
@@ -249,7 +249,7 @@ public sealed class BenchmarkRunner(BenchmarkConfig config)
     runStopwatch.Stop();
     await memorySampler.StopAsync();
 
-    return new BenchmarkResult(
+    var result = new BenchmarkResult(
         engineName,
         durability,
         startedAt,
@@ -271,6 +271,20 @@ public sealed class BenchmarkRunner(BenchmarkConfig config)
     {
       InterruptedPhase = interruptedPhase
     };
+
+    PrintRunSummary(result);
+    return result;
+  }
+
+  static void PrintRunSummary(BenchmarkResult result)
+  {
+    var completedPhaseMs = result.Phases.Sum(x => x.ElapsedMs);
+    Console.WriteLine();
+    Console.WriteLine($"  run time: {result.RunElapsedMs / 1000:N2}s");
+    Console.WriteLine($"  completed phase time: {completedPhaseMs / 1000:N2}s");
+    Console.WriteLine(
+        $"  process peak memory: {ResultWriter.FormatBytes(result.PeakProcessWorkingSetBytes)}");
+    Console.WriteLine();
   }
 
   BenchmarkWorkloadConfig CreateWorkloadConfig()

--- a/docs/concepts/bloom-filters.md
+++ b/docs/concepts/bloom-filters.md
@@ -23,8 +23,9 @@ using var zoneTree = new ZoneTreeFactory<long, string>()
 The default is `8`. Valid values are `0` through `64`; `0` disables the
 filter. Higher values generally reduce false positives at the cost of a larger
 allocation. They do not eliminate the ordinary lookup after a possible match.
-Disabling the filter does not remove the current requirement for a configured
-key hasher; the factory supplies one automatically for supported key types.
+An enabled filter requires a key hasher. The factory supplies one automatically
+for supported key types. For other key types, configure a compatible hasher or
+set the value to `0` to disable the filter.
 
 Filter size also depends on `MutableSegmentMaxItemCount`. ZoneTree multiplies
 that configured capacity by the requested bits per item, uses at least 64

--- a/docs/concepts/serializers-and-comparers.md
+++ b/docs/concepts/serializers-and-comparers.md
@@ -46,6 +46,10 @@ public interface IKeyHasher<TKey>
 }
 ```
 
+A key hasher is required when the mutable-segment Bloom filter is enabled.
+Setting `MutableSegmentBloomFilterBitsPerItem` to `0` disables the filter and
+removes this requirement.
+
 The required invariant is:
 
 > If the configured comparer considers two keys equal, the configured hasher
@@ -103,7 +107,7 @@ ZoneTree metadata records:
 
 * key and value types,
 * comparer type,
-* key-hasher type,
+* key-hasher type, when configured,
 * key- and value-serializer types,
 * mutable-segment Bloom-filter density.
 
@@ -113,6 +117,5 @@ type, comparer type, key-serializer type, and value-serializer type.
 Type checks cannot detect a behavioral change inside the same .NET type.
 Changing comparer ordering or serializer bytes is a storage migration: create
 a new ZoneTree and copy or rebuild the data. A hasher can be changed without
-rewriting persisted data, but the replacement must still satisfy the comparer
-equality invariant because in-memory Bloom filters are built with the active
-hasher.
+rewriting persisted data. When the mutable-segment Bloom filter is enabled,
+the replacement must still satisfy the comparer equality invariant.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -12,7 +12,8 @@ Common causes:
 * key/value type mismatch,
 * comparer or serializer type mismatch,
 * incompatible persisted comparer behavior,
-* a case-insensitive string comparer paired with an incompatible hasher,
+* with Bloom filtering enabled, a case-insensitive string comparer paired with
+  an incompatible hasher,
 * metadata or WAL corruption.
 
 First actions:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,7 +17,8 @@ tree. Configure components and options before calling an open method.
 | opening | `Create`, `Open`, `OpenOrCreate`, transactional variants |
 
 Known key/value types receive default serializers and, where applicable,
-comparers and key hashers. Custom types require explicit compatible components.
+comparers and key hashers. Custom types require explicit compatible components;
+a key hasher is required only when the mutable-segment Bloom filter is enabled.
 
 ## Core Defaults
 
@@ -45,13 +46,6 @@ The public property identifiers `BTreeLockMode`, `BTreeNodeSize`, and
 | `ValueSerializer` | defines persisted value bytes |
 | deletion delegates | define and create deletion markers |
 
-Metadata records all four component type names. On open, ZoneTree validates
-the comparer and serializer types, but it does not currently reject a changed
-key-hasher type. A comparer-order or serializer-format change is a storage
-migration even when the .NET type name stays the same. A replacement hasher
-does not change persisted data, but it must remain compatible with comparer
-equality.
-
 ## Mutable-Segment Bloom Filter
 
 The filter is sized from `MutableSegmentMaxItemCount` and
@@ -65,9 +59,9 @@ using var zoneTree = new ZoneTreeFactory<long, string>()
     .OpenOrCreate();
 ```
 
-Use `0` bits per item to disable the filter. A larger value is not free: it
-increases memory and does not eliminate comparer-based lookup after a possible
-match.
+Use `0` bits per item to disable the filter and remove the key-hasher
+requirement. A larger value is not free: it increases memory and does not
+eliminate comparer-based lookup after a possible match.
 
 See [mutable-segment Bloom filters](../concepts/bloom-filters.md) for sizing,
 false-positive behavior, and hasher requirements.

--- a/docs/usage/opening-a-tree.md
+++ b/docs/usage/opening-a-tree.md
@@ -63,8 +63,8 @@ using var zoneTree = new ZoneTreeFactory<int, string>()
 ```
 
 ZoneTree fills serializers, comparers, and hashers for supported known types.
-When supplying a custom comparer, ensure comparer-equal keys produce the same
-hash.
+When Bloom filtering is enabled with a custom comparer, ensure comparer-equal
+keys produce the same hash.
 
 ## Dispose
 

--- a/src/ZoneTree.UnitTests/ZoneTreeOptionsValidationTests.cs
+++ b/src/ZoneTree.UnitTests/ZoneTreeOptionsValidationTests.cs
@@ -80,6 +80,30 @@ public sealed class ZoneTreeOptionsValidationTests
   }
 
   [Test]
+  public void MissingKeyHasherPassesValidationWhenBloomFilterIsDisabled()
+  {
+    var options = CreateValidOptions();
+    options.KeyHasher = null;
+    options.MutableSegmentBloomFilterBitsPerItem = 0;
+
+    Assert.That(options.TryValidate(out var exception), Is.True);
+    Assert.That(exception, Is.Null);
+  }
+
+  [Test]
+  public void MissingKeyHasherExplainsHowToDisableBloomFilter()
+  {
+    var options = CreateValidOptions();
+    options.KeyHasher = null;
+
+    var exception = Assert.Throws<MissingOptionException>(options.Validate);
+
+    Assert.That(
+        exception.Message,
+        Does.Contain($"set {nameof(options.MutableSegmentBloomFilterBitsPerItem)} to 0"));
+  }
+
+  [Test]
   public void AllowUnsafeOptionValuesSkipsNumericRanges()
   {
     var options = CreateValidOptions();

--- a/src/ZoneTree/Directory.Build.props
+++ b/src/ZoneTree/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree</PackageId>
     <Title>ZoneTree</Title>
-    <ProductVersion>1.9.6.0</ProductVersion>
-    <Version>1.9.6.0</Version>
+    <ProductVersion>1.9.7.0</ProductVersion>
+    <Version>1.9.7.0</Version>
     <AssemblyTitle>ZoneTree</AssemblyTitle>
     <Description>ZoneTree is a persistent, high-performance, transactional, ACID-compliant ordered key-value database and LSM-tree storage engine for .NET.</Description>
     <Summary>

--- a/src/ZoneTree/Exceptions/MissingOptionException.cs
+++ b/src/ZoneTree/Exceptions/MissingOptionException.cs
@@ -8,5 +8,11 @@ public sealed class MissingOptionException : ZoneTreeException
     MissingOption = missingOption;
   }
 
+  public MissingOptionException(string missingOption, string resolution)
+      : base($"ZoneTree {missingOption} option is not provided. {resolution}")
+  {
+    MissingOption = missingOption;
+  }
+
   public string MissingOption { get; }
 }

--- a/src/ZoneTree/Options/ZoneTreeOptions.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptions.cs
@@ -46,7 +46,8 @@ public sealed class ZoneTreeOptions<TKey, TValue>
   /// Requested Bloom-filter bits per mutable-segment item. Higher values reduce
   /// false positives but use more memory. The allocation is rounded up to a
   /// power of two. Setting this value to zero disables the mutable-segment
-  /// Bloom filter. Valid values are between 0 and 64. Default value is 8.
+  /// Bloom filter. A key hasher is required when this value is greater than
+  /// zero. Valid values are between 0 and 64. Default value is 8.
   /// </summary>
   public int MutableSegmentBloomFilterBitsPerItem { get; set; } =
       DefaultValues.MutableSegmentBloomFilterBitsPerItem;
@@ -65,7 +66,8 @@ public sealed class ZoneTreeOptions<TKey, TValue>
 
   /// <summary>
   /// The key hasher. Keys considered equal by <see cref="Comparer"/> must
-  /// produce the same hash code.
+  /// produce the same hash code. Required when
+  /// <see cref="MutableSegmentBloomFilterBitsPerItem"/> is greater than zero.
   /// </summary>
   public IKeyHasher<TKey> KeyHasher { get; set; }
 

--- a/src/ZoneTree/Options/ZoneTreeOptionsValidator.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptionsValidator.cs
@@ -23,8 +23,16 @@ internal static class ZoneTreeOptionsValidator
     if (options.Comparer == null)
       return new MissingOptionException(nameof(options.Comparer));
 
-    if (options.KeyHasher == null)
-      return new MissingOptionException(nameof(options.KeyHasher));
+    var mutableSegmentBloomFilterEnabled =
+        options.MutableSegmentBloomFilterBitsPerItem > 0;
+    if (mutableSegmentBloomFilterEnabled && options.KeyHasher == null)
+    {
+      return new MissingOptionException(
+          nameof(options.KeyHasher),
+          $"Configure a compatible key hasher or set " +
+          $"{nameof(options.MutableSegmentBloomFilterBitsPerItem)} to 0 " +
+          "to disable the mutable-segment Bloom filter.");
+    }
 
     if (options.IsDeleted == null)
       return new MissingOptionException(nameof(options.IsDeleted));
@@ -47,9 +55,13 @@ internal static class ZoneTreeOptionsValidator
     if (options.DiskSegmentOptions == null)
       return new MissingOptionException(nameof(options.DiskSegmentOptions));
 
-    Exception exception = ValidateCommonKeyHasherCompatibility(options);
-    if (exception != null)
-      return exception;
+    Exception exception = null;
+    if (mutableSegmentBloomFilterEnabled)
+    {
+      exception = ValidateCommonKeyHasherCompatibility(options);
+      if (exception != null)
+        return exception;
+    }
 
     exception = ValidateDefinedEnum(
         nameof(options.BTreeLockMode),

--- a/src/ZoneTree/Segments/InMemory/MutableSegment.cs
+++ b/src/ZoneTree/Segments/InMemory/MutableSegment.cs
@@ -272,6 +272,8 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
   ConcurrentBloomFilter CreateBloomFilter(
       ZoneTreeOptions<TKey, TValue> options)
   {
+    if (options.KeyHasher == null)
+      return null;
     var bitsPerItem = options.MutableSegmentBloomFilterBitsPerItem;
     return bitsPerItem == 0 ?
         null :


### PR DESCRIPTION
## Summary

- Make `KeyHasher` optional when `MutableSegmentBloomFilterBitsPerItem` is set to `0`
- Skip key-hasher compatibility validation when the mutable-segment Bloom filter is disabled
- Improve missing-key-hasher validation messaging with guidance to configure a hasher or disable Bloom filtering
- Update docs to clarify when key hashers are required and how disabling Bloom filtering affects that requirement
- Add validation tests for missing hashers with Bloom filtering disabled
- Print a short profile-store benchmark run summary with runtime and peak memory
- Bump ZoneTree package version to `1.9.7.0`