### PR TITLE
Relax flush to disk in disk segment creation.

### DIFF
--- a/src/ZoneTree/Segments/RandomAccess/CompressedFileRandomAccessDevice.cs
+++ b/src/ZoneTree/Segments/RandomAccess/CompressedFileRandomAccessDevice.cs
@@ -236,7 +236,10 @@ public sealed class CompressedFileRandomAccessDevice : IRandomAccessDevice
     CompressedBlockLengths.Add(compressedBytes.Length);
     DecompressedBlockLengths.Add(nextBlock.Length);
     FileStream.Write(compressedBytes.Span);
-    FileStream.Flush(true);
+    // Avoid forcing every compression block to stable storage. A compressed
+    // device is not valid or publishable until SealDevice writes its terminal
+    // block metadata and durably flushes the complete file.
+    FileStream.Flush(false);
     BlockCache.RemoveBlock(nextBlock.BlockIndex);
     ++NextBlockIndex;
     LastBlockLength = 0;


### PR DESCRIPTION
## Summary

- Relax compressed random-access device flushing during disk segment creation
- Change per-compressed-block flushes from durable `Flush(true)` to buffered `Flush(false)`
- Preserve durability at the publish point: `SealDevice` still writes terminal block metadata and durably flushes the complete compressed file
- Document the reasoning inline so the per-block flush behavior is clear