### PR TITLE
.NET 8.0 support via Backport.System.Threading.Lock

### DIFF
--- a/src/ZoneTree.UnitTests/BottomSegmentMergeTests.cs
+++ b/src/ZoneTree.UnitTests/BottomSegmentMergeTests.cs
@@ -1,11 +1,10 @@
-using System.Text.Json;
 using System.Reflection;
-using ZoneTree.Collections;
 using ZoneTree.AbstractFileStream;
+using ZoneTree.Collections;
 using ZoneTree.Comparers;
 using ZoneTree.Core;
-using ZoneTree.Logger;
 using ZoneTree.Hashers;
+using ZoneTree.Logger;
 using ZoneTree.Options;
 using ZoneTree.Segments;
 using ZoneTree.Segments.Disk;
@@ -446,8 +445,7 @@ public sealed class BottomSegmentMergeTests
         .Concat(bottomSegments)
         .ToArray();
     var newQueue =
-        new SingleProducerSingleConsumerQueue<IDiskSegment<int, int>>(
-            newBottomSegments.Reverse());
+        new SingleProducerSingleConsumerQueue<IDiskSegment<int, int>>(Enumerable.Reverse(newBottomSegments));
     var field = typeof(ZoneTree<int, int>).GetField(
         "BottomSegmentQueue",
         BindingFlags.Instance | BindingFlags.NonPublic);

--- a/src/ZoneTree.UnitTests/ZoneTree.UnitTests.csproj
+++ b/src/ZoneTree.UnitTests/ZoneTree.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <LangVersion>14</LangVersion>

--- a/src/ZoneTree.UnitTests/ZoneTree.UnitTests.csproj
+++ b/src/ZoneTree.UnitTests/ZoneTree.UnitTests.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-
+    <LangVersion>14</LangVersion>
     <IsPackable>false</IsPackable>
 
     <RootNamespace>ZoneTree.UnitTests</RootNamespace>
@@ -23,6 +23,10 @@
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Backport.System.Threading.Lock" Version="3.1.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/ZoneTree/ZoneTree.csproj
+++ b/src/ZoneTree/ZoneTree.csproj
@@ -4,7 +4,7 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <LangVersion>14.0</LangVersion>
     <RepositoryUrl>https://github.com/ZoneTree/ZoneTree</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -22,6 +22,7 @@
     <Configurations>Debug;Release;ReleaseWithDoc</Configurations>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
     <RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'ReleaseWithDoc'">
@@ -47,5 +48,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Backport.System.Threading.Lock" Version="3.1.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description

This PR introduces support for .NET 8.0 across the library and test projects to ensure full compatibility with the current Long Term Support (LTS) release, which remains actively supported and widely used in production.

To maintain System.Threading.Lock optimizations without introducing runtime dependencies, the [Backport.System.Threading.Lock](https://github.com/MarkCiliaVincenti/Backport.System.Threading.Lock) source generator has been integrated.

### Summary of Changes

* **Multi-targeting update:** Added `net8.0` to the target frameworks in the main library `.csproj`.
* **Zero runtime dependency backport:** Included `Backport.System.Threading.Lock` as an analyzer/source generator, enabling modern locking patterns across supported target frameworks without adding external runtime package dependencies.
* **Test suite multi-targeting:** Updated test project targets to execute unit tests against all supported target frameworks.

### Testing

* Ran the complete unit test suite across all configured target frameworks.
* All tests passed successfully with zero regressions.