### PR TITLE
Add support for .net 6, 7 and 8

### DIFF
--- a/src/ZoneTree/Compatibility/ArgumentOutOfRangeExceptionPolyfill.cs
+++ b/src/ZoneTree/Compatibility/ArgumentOutOfRangeExceptionPolyfill.cs
@@ -1,0 +1,66 @@
+#if NET7_0 || NET6_0
+using System.Runtime.CompilerServices;
+
+namespace ZoneTree.AbstractFileStream
+{
+internal sealed class ArgumentOutOfRangeException
+    : global::System.ArgumentOutOfRangeException
+{
+  public ArgumentOutOfRangeException(string paramName)
+      : base(paramName)
+  {
+  }
+
+  public ArgumentOutOfRangeException(
+      string paramName,
+      object actualValue,
+      string message)
+      : base(paramName, actualValue, message)
+  {
+  }
+
+  public static void ThrowIfNegative(
+      int value,
+      [CallerArgumentExpression(nameof(value))] string paramName = null)
+  {
+    if (value < 0)
+      throw new ArgumentOutOfRangeException(paramName, value, null);
+  }
+
+  public static void ThrowIfNegative(
+      long value,
+      [CallerArgumentExpression(nameof(value))] string paramName = null)
+  {
+    if (value < 0)
+      throw new ArgumentOutOfRangeException(paramName, value, null);
+  }
+
+  public static void ThrowIfLessThanOrEqual(
+      TimeSpan value,
+      TimeSpan other,
+      [CallerArgumentExpression(nameof(value))] string paramName = null)
+  {
+    if (value <= other)
+      throw new ArgumentOutOfRangeException(paramName, value, null);
+  }
+}
+}
+
+namespace ZoneTree.Backup
+{
+internal static class ArgumentOutOfRangeException
+{
+  public static void ThrowIfLessThanOrEqual(
+      TimeSpan value,
+      TimeSpan other,
+      [CallerArgumentExpression(nameof(value))] string paramName = null)
+  {
+    if (value <= other)
+      throw new global::System.ArgumentOutOfRangeException(
+          paramName,
+          value,
+          null);
+  }
+}
+}
+#endif

--- a/src/ZoneTree/Compatibility/Lock.net8.cs
+++ b/src/ZoneTree/Compatibility/Lock.net8.cs
@@ -1,0 +1,31 @@
+#if NET8_0 || NET7_0 || NET6_0
+namespace System.Threading;
+
+#pragma warning disable CS9216, CA2002
+
+internal sealed class Lock
+{
+  public Scope EnterScope()
+  {
+    Monitor.Enter(this);
+    return new Scope(this);
+  }
+
+  public readonly ref struct Scope
+  {
+    readonly Lock Target;
+
+    internal Scope(Lock target)
+    {
+      Target = target;
+    }
+
+    public void Dispose()
+    {
+      Monitor.Exit(Target);
+    }
+  }
+}
+
+#pragma warning restore CS9216, CA2002
+#endif

--- a/src/ZoneTree/Compatibility/ObjectDisposedExceptionPolyfill.cs
+++ b/src/ZoneTree/Compatibility/ObjectDisposedExceptionPolyfill.cs
@@ -1,0 +1,59 @@
+#if NET6_0
+namespace ZoneTree.AbstractFileStream
+{
+internal static class ObjectDisposedException
+{
+  public static void ThrowIf(bool condition, object instance)
+  {
+    if (condition)
+      throw new global::System.ObjectDisposedException(
+          instance?.GetType().FullName);
+  }
+}
+}
+
+namespace ZoneTree.Backup
+{
+internal sealed class ObjectDisposedException
+    : global::System.ObjectDisposedException
+{
+  public ObjectDisposedException(string objectName)
+      : base(objectName)
+  {
+  }
+
+  public static void ThrowIf(bool condition, object instance)
+  {
+    if (condition)
+      throw new global::System.ObjectDisposedException(
+          instance?.GetType().FullName);
+  }
+}
+}
+
+namespace ZoneTree.Segments.Disk
+{
+internal static class ObjectDisposedException
+{
+  public static void ThrowIf(bool condition, object instance)
+  {
+    if (condition)
+      throw new global::System.ObjectDisposedException(
+          instance?.GetType().FullName);
+  }
+}
+}
+
+namespace ZoneTree.Segments.MultiPart
+{
+internal static class ObjectDisposedException
+{
+  public static void ThrowIf(bool condition, object instance)
+  {
+    if (condition)
+      throw new global::System.ObjectDisposedException(
+          instance?.GetType().FullName);
+  }
+}
+}
+#endif

--- a/src/ZoneTree/ZoneTree.csproj
+++ b/src/ZoneTree/ZoneTree.csproj
@@ -4,7 +4,7 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <LangVersion>14.0</LangVersion>
     <RepositoryUrl>https://github.com/ZoneTree/ZoneTree</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -42,7 +42,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="'$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net6.0'">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="'$(TargetFramework)' != 'net7.0' and '$(TargetFramework)' != 'net6.0'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
**Description**
This PR expands ZoneTree’s supported target frameworks from `net10.0;net9.0` to:

```text
net10.0;net9.0;net8.0;net7.0;net6.0
```

To keep the existing codebase compatible without broad call-site rewrites, it adds small conditional polyfills for APIs that are unavailable on older TFMs:

- `System.Threading.Lock` for `net8.0`, `net7.0`, and `net6.0`
- `ArgumentOutOfRangeException.ThrowIfNegative(...)` and `ThrowIfLessThanOrEqual(...)` for `net7.0` and `net6.0`
- `ObjectDisposedException.ThrowIf(...)` for `net6.0`

The PR also uses `Microsoft.SourceLink.GitHub 8.0.0` for `net6.0` and `net7.0`, while keeping `10.0.300` for newer TFMs. This avoids the transitive `System.IO.Hashing 10.0.8` unsupported-framework warning on older targets.
