### PR TITLE
Adds bounded retry/backoff around LocalFileStreamProvider.Replace to handle transient File.Replace failures on Windows

### DIFF
--- a/src/ZoneTree.UnitTests/LocalFileStreamProviderTests.cs
+++ b/src/ZoneTree.UnitTests/LocalFileStreamProviderTests.cs
@@ -1,0 +1,73 @@
+using ZoneTree.AbstractFileStream;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class LocalFileStreamProviderTests
+{
+  [Test]
+  public void ReplaceRetriesTransientIoExceptionAndEventuallySucceeds()
+  {
+    var attemptCount = 0;
+    var delays = new List<int>();
+    var provider = new LocalFileStreamProvider(
+        (_, _, _) =>
+        {
+          ++attemptCount;
+          if (attemptCount < 3)
+            throw new IOException("Unable to remove the file to be replaced.");
+        },
+        delays.Add);
+
+    provider.Replace("source", "destination", null);
+
+    Assert.Multiple(() =>
+    {
+      Assert.That(attemptCount, Is.EqualTo(3));
+      Assert.That(delays, Is.EqualTo([10, 25]));
+    });
+  }
+
+  [Test]
+  public void ReplaceRethrowsAfterBoundedRetryAttempts()
+  {
+    var attemptCount = 0;
+    var delays = new List<int>();
+    var provider = new LocalFileStreamProvider(
+        (_, _, _) =>
+        {
+          ++attemptCount;
+          throw new IOException("Unable to remove the file to be replaced.");
+        },
+        delays.Add);
+
+    Assert.Throws<IOException>(() => provider.Replace("source", "destination", null));
+
+    Assert.Multiple(() =>
+    {
+      Assert.That(attemptCount, Is.EqualTo(6));
+      Assert.That(delays, Is.EqualTo([10, 25, 50, 100, 200]));
+    });
+  }
+
+  [Test]
+  public void ReplaceDoesNotRetryMissingSourceFile()
+  {
+    var attemptCount = 0;
+    var delays = new List<int>();
+    var provider = new LocalFileStreamProvider(
+        (_, _, _) =>
+        {
+          ++attemptCount;
+          throw new FileNotFoundException("source");
+        },
+        delays.Add);
+
+    Assert.Throws<FileNotFoundException>(() => provider.Replace("source", "destination", null));
+
+    Assert.Multiple(() =>
+    {
+      Assert.That(attemptCount, Is.EqualTo(1));
+      Assert.That(delays, Is.Empty);
+    });
+  }
+}

--- a/src/ZoneTree/AbstractFileStream/LocalFileStreamProvider.cs
+++ b/src/ZoneTree/AbstractFileStream/LocalFileStreamProvider.cs
@@ -2,6 +2,25 @@ namespace ZoneTree.AbstractFileStream;
 
 public sealed class LocalFileStreamProvider : IFileStreamProvider
 {
+  static readonly int[] ReplaceRetryDelaysMilliseconds = { 10, 25, 50, 100, 200 };
+
+  readonly Action<string, string, string> ReplaceFile;
+
+  readonly Action<int> Sleep;
+
+  public LocalFileStreamProvider()
+      : this(File.Replace, Thread.Sleep)
+  {
+  }
+
+  internal LocalFileStreamProvider(
+      Action<string, string, string> replaceFile,
+      Action<int> sleep)
+  {
+    ReplaceFile = replaceFile;
+    Sleep = sleep;
+  }
+
   public IFileStream CreateFileStream(
       string path,
       FileMode mode,
@@ -55,7 +74,27 @@ public sealed class LocalFileStreamProvider : IFileStreamProvider
   {
     // File Replace is a fast operation in local filesystem. 
     // It uses file rename operation and it is atomic.
-    File.Replace(sourceFileName, destinationFileName, destinationBackupFileName);
+    for (var attempt = 0; ; ++attempt)
+    {
+      try
+      {
+        ReplaceFile(sourceFileName, destinationFileName, destinationBackupFileName);
+        return;
+      }
+      catch (IOException exception) when (CanRetryReplace(exception, attempt))
+      {
+        Sleep(ReplaceRetryDelaysMilliseconds[attempt]);
+      }
+    }
+  }
+
+  static bool CanRetryReplace(IOException exception, int attempt)
+  {
+    return attempt < ReplaceRetryDelaysMilliseconds.Length &&
+        exception is not FileNotFoundException &&
+        exception is not DirectoryNotFoundException &&
+        exception is not DriveNotFoundException &&
+        exception is not PathTooLongException;
   }
 
   public DurableFileWriter GetDurableFileWriter()

--- a/src/ZoneTree/Properties/AssemblyInfo.cs
+++ b/src/ZoneTree/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ZoneTree.UnitTests")]


### PR DESCRIPTION
## Summary

Adds bounded retry/backoff around `LocalFileStreamProvider.Replace` to handle transient `File.Replace` failures on Windows, such as watcher-related interference from tools like editors or file indexers.

The implementation preserves ZoneTree’s existing atomic replacement behavior by continuing to use `File.Replace`; it only retries transient `IOException`s before surfacing the original failure.

## Changes

- Retry `File.Replace` on retryable `IOException`s with short bounded backoff delays: `10ms`, `25ms`, `50ms`, `100ms`, `200ms`.
- Avoid retries for structural path/file errors such as:
  - `FileNotFoundException`
  - `DirectoryNotFoundException`
  - `DriveNotFoundException`
  - `PathTooLongException`
- Add deterministic unit tests for:
  - eventual success after transient failures
  - rethrow after retry exhaustion
  - no retry for missing source file

## Motivation

On Windows, `File.Replace` may fail transiently with errors like “Unable to remove the file to be replaced” when another process has a `FileSystemWatcher` active on the directory. Retrying briefly handles that interference without replacing the atomic operation with a less durable delete/move fallback.